### PR TITLE
Add python_requires and classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,12 @@ setup(
     license='MIT',
     packages=['python_jwt'],
     install_requires=['jwcrypto>=0.4.2'],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
+    classifiers=[
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
+    ],
 )


### PR DESCRIPTION
This assumes 2.7 and 3.6+ are the minimum supported versions, by looking at .travis.yml. Is that correct?

`python_requires` helps pip install the correct version of the package depending on the user's Python version. 

See https://packaging.python.org/guides/dropping-older-python-versions/ for more info

Also adds some Trove classifiers to make PyPI listings clearer.