### PR TITLE
docs: Fix a few typos

### DIFF
--- a/coverage/html/jquery.isonscreen.js
+++ b/coverage/html/jquery.isonscreen.js
@@ -8,7 +8,7 @@
 (function($) {
 	jQuery.extend({
 		isOnScreen: function(box, container) {
-			//ensure numbers come in as intgers (not strings) and remove 'px' is it's there
+			//ensure numbers come in as integers (not strings) and remove 'px' is it's there
 			for(var i in box){box[i] = parseFloat(box[i])};
 			for(var i in container){container[i] = parseFloat(container[i])};
 

--- a/python_jwt/__init__.py
+++ b/python_jwt/__init__.py
@@ -116,7 +116,7 @@ def verify_jwt(jwt,
     :param allowed_algs: Algorithms expected to be used to sign the token. The ``in`` operator is used to test membership.
     :type allowed_algs: list or NoneType (meaning an empty list)
 
-    :param iat_skew: The amount of leeway to allow between the issuer's clock and the verifier's clock when verifiying that the token was generated in the past. Defaults to no leeway.
+    :param iat_skew: The amount of leeway to allow between the issuer's clock and the verifier's clock when verifying that the token was generated in the past. Defaults to no leeway.
     :type iat_skew: datetime.timedelta
 
     :param checks_optional: If ``False``, then the token must contain the **typ** header property and the **iat**, **nbf** and **exp** claim properties.


### PR DESCRIPTION
There are small typos in:
- coverage/html/jquery.isonscreen.js
- python_jwt/__init__.py

Fixes:
- Should read `verifying` rather than `verifiying`.
- Should read `integers` rather than `intgers`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md